### PR TITLE
Support Windows normalization of baseURL.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -24,8 +24,9 @@ function getMapMatch(map, name) {
 function prepareBaseURL(loader) {
   // ensure baseURl is fully normalized
   if (this._loader.baseURL !== this.baseURL) {
-    if (this.baseURL[this.baseURL.length - 1] != '/')
-      this.baseURL += '/';
+    var sep = isWindows ? '\\' : '/';
+    if (this.baseURL[this.baseURL.length - 1] != sep)
+      this.baseURL += sep;
     
     this._loader.baseURL = this.baseURL = new URL(this.baseURL, baseURIObj).href;
   }


### PR DESCRIPTION
Changed prepareBaseURL() to use backslash ('\') when normalizing baseURL on Windows.